### PR TITLE
fix(reports): align all 5 summary cards on one row, rename Avg Conf label

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -666,7 +666,7 @@
           <div class="rep-card"><div class="rep-card-val" id="rep-card-max">—</div><div class="rep-card-label">Max |θ| [°]</div></div>
           <div class="rep-card"><div class="rep-card-val" id="rep-card-updates">—</div><div class="rep-card-label">AI Updates</div></div>
           <div class="rep-card"><div class="rep-card-val" id="rep-card-forced">—</div><div class="rep-card-label">Forced</div></div>
-          <div class="rep-card"><div class="rep-card-val" id="rep-card-conf">—</div><div class="rep-card-label">Avg Conf</div></div>
+          <div class="rep-card"><div class="rep-card-val" id="rep-card-conf">—</div><div class="rep-card-label">Model Confidence</div></div>
         </div>
 
         <!-- Two-column body: left (charts + phase table) | right (decision history) -->

--- a/public/reports-ui.css
+++ b/public/reports-ui.css
@@ -146,7 +146,7 @@
 #reports-summary {
   flex: 0 0 auto;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   gap: 10px;
   padding: 8px 12px;
   border-bottom: 1px solid var(--border);

--- a/public/reports-ui.js
+++ b/public/reports-ui.js
@@ -377,7 +377,7 @@ class ReportsUI {
         confEl.textContent = avg.toFixed(2);
         confEl.style.color = color;
         const labelEl = confEl.parentElement?.querySelector('.rep-card-label');
-        if (labelEl) labelEl.textContent = `Avg Conf (${label})`;
+        if (labelEl) labelEl.textContent = `Model Confidence (${label})`;
       } else {
         confEl.textContent = '—';
         confEl.style.color = '';


### PR DESCRIPTION
## Summary

- Fix `#reports-summary` grid column count from 4 to 5 so all cards render on a single row without wrapping
- Rename **Avg Conf** / **Avg Conf (LEVEL)** label to **Model Confidence (LEVEL)** across `index.html` and `reports-ui.js`

## Changes

| File | Change |
|------|--------|
| `public/reports-ui.css` | `grid-template-columns: repeat(4 → 5, 1fr)` |
| `public/index.html` | Default label `Avg Conf` → `Model Confidence` |
| `public/reports-ui.js` | Dynamic label `Avg Conf (${label})` → `Model Confidence (${label})` |

## Test plan

- [ ] Open REPORTS tab and load any saved AI session
- [ ] Confirm all 5 summary cards (Avg |θ|, Max |θ|, AI Updates, Forced, Model Confidence) appear on one row
- [ ] Confirm the confidence card label reads `Model Confidence (LOW/MED/HIGH)` depending on the session data

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)